### PR TITLE
Change HttpUrl to AnyHttpUrl

### DIFF
--- a/auto_labeling_pipeline/models.py
+++ b/auto_labeling_pipeline/models.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Type
 
 import boto3
 import requests
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, AnyHttpUrl
 from typing_extensions import Literal
 
 
@@ -43,7 +43,7 @@ class CustomRESTRequestModel(RequestModel):
     """
     This allow you to call any REST API.
     """
-    url: HttpUrl
+    url: AnyHttpUrl
     method: Literal['GET', 'POST']
     params: Optional[dict]
     headers: Optional[dict]

--- a/auto_labeling_pipeline/models.py
+++ b/auto_labeling_pipeline/models.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Type
 
 import boto3
 import requests
-from pydantic import BaseModel, AnyHttpUrl
+from pydantic import AnyHttpUrl, BaseModel
 from typing_extensions import Literal
 
 


### PR DESCRIPTION
Hi!

First of all, thanks for the outstanding tool you are building, @Hironsan! I have used it in several projects with awesome results!
I was just trying out the AutoLabeling feature with a local API, exposed at http://localhost:81. 
Nevertheless, an error message always kept me from finishing the configuration:
>  The attributes does not match the model.You need to correctly specify the required fields: url, method 

It turns out that the Pydantic validator at https://github.com/doccano/auto-labeling-pipeline/blob/fa52f4dbafd47aa9435c2267b68ab6ad718b48f0/auto_labeling_pipeline/models.py#L46
requires the url field to have a TLD (i.e. to be like a .com). Indeed, I was able to complete the Custom REST testing stage by using a `.local` address (which maps to localhost).

I'd suggest to change the validation to `AnyHttpUrl`, as the [Pydantic docs](https://pydantic-docs.helpmanual.io/usage/types/#urls) indicate that it drops the TLD requirement, so as to facilitate local testing.

Thanks in advance!