### PR TITLE
Fix find method to be able to find sub sub classes

### DIFF
--- a/auto_labeling_pipeline/models.py
+++ b/auto_labeling_pipeline/models.py
@@ -24,7 +24,14 @@ class RequestModelFactory:
 
     @classmethod
     def find(cls, model_name: str) -> Type[RequestModel]:
-        for subclass in RequestModel.__subclasses__():
+        def get_all_subclasses(cls):
+            all_subclasses = []
+            for subclass in cls.__subclasses__():
+                all_subclasses.append(subclass)
+                all_subclasses.extend(get_all_subclasses(subclass))
+            return all_subclasses
+
+        for subclass in get_all_subclasses(RequestModel):
             if subclass.Config.title == model_name:
                 return subclass
         raise NameError(f'{model_name} is not found.')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,11 @@ def load_image_as_b64(filepath):
         return b64_image.decode('utf-8')
 
 
+def test_find_model():
+    model = RequestModelFactory.find('Amazon Comprehend Sentiment Analysis')
+    assert model == AmazonComprehendSentimentRequestModel
+
+
 def test_request_model_raises_type_error_on_instantiation():
     with pytest.raises(TypeError):
         RequestModel()


### PR DESCRIPTION
# Description

Currently, auto-labeling-pipeline can't find model classes recursively.
This PR fixes the problem.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] test_find_models
