### PR TITLE
Custom Reset Request does not support lists in

### DIFF
--- a/auto_labeling_pipeline/models.py
+++ b/auto_labeling_pipeline/models.py
@@ -39,12 +39,16 @@ class RequestModelFactory:
 
 
 def find_and_replace_value(obj, value, target='{{ text }}'):
-    for k, v in obj.items():
-        if v == target:
-            obj[k] = value
-            return
-        if isinstance(v, dict):
-            find_and_replace_value(v, value, target)
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if v == target:
+                obj[k] = value
+                return
+            if isinstance(v, (dict, list)):
+                find_and_replace_value(v, value, target)
+    if isinstance(obj, list):
+        for item in obj:
+            find_and_replace_value(item, value, target)
 
 
 class CustomRESTRequestModel(RequestModel):


### PR DESCRIPTION
Given we have the following request body:
```json
{
  "instances": [
    {
      text: "{{ text }}"
    }
    ]
}
```
The following method is unable to replace "{{ text }}" with the appropriate text.

```python
def find_and_replace_value(obj, value, target='{{ text }}'):
    for k, v in obj.items():
        if v == target:
            obj[k] = value
            return
        if isinstance(v, dict):
            find_and_replace_value(v, value, target)
```

The proposed changes would address this issue.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
